### PR TITLE
Fixing some bugs

### DIFF
--- a/PkmnRaceBattle.API/Helpers/MoveManager/Fights/FightAilmentMove.cs
+++ b/PkmnRaceBattle.API/Helpers/MoveManager/Fights/FightAilmentMove.cs
@@ -47,6 +47,7 @@ namespace PkmnRaceBattle.API.Helpers.MoveManager.Fights
                         turnContext.AddMessage(defenser.NameFr + " s'endort");
                         break;
                     case "confusion":
+                        if (defenser.IsConfused != 0) { turnContext.AddMessage(defenser.NameFr + " est déjà confus"); return defenser; }
                         Random rnde = new Random();
                         defenser.IsConfused = rnde.Next(1, 5);
                         turnContext.AddMessage("Cela rend " + defenser.NameFr + " confus");

--- a/PkmnRaceBattle.API/Helpers/MoveManager/Fights/FightDamageMove.cs
+++ b/PkmnRaceBattle.API/Helpers/MoveManager/Fights/FightDamageMove.cs
@@ -107,7 +107,7 @@ namespace PkmnRaceBattle.API.Helpers.MoveManager.Fights
             double typeEffectiveness = CalculateTypeEffectiveness(move.Type, defenser.Types, turnContext);
             if (typeEffectiveness == 0.0) attacker = FightPerformMove.SpecialCaseMissMove(attacker, move, turnContext);
             double critical = 1.0;
-            if(IsCriticalHit(attacker, move))
+            if (move.NameFr != "Confusion" && IsCriticalHit(attacker, move))
             {
                 turnContext.AddMessage("Coup critique !");
                 critical = 1.5;
@@ -244,7 +244,7 @@ namespace PkmnRaceBattle.API.Helpers.MoveManager.Fights
 
                 case "fire":
                     string[] fireStrongness = ["steel", "ice", "bug", "grass"];
-                    string[] fireWeakness = ["dragon", "water", "fire"];
+                    string[] fireWeakness = ["dragon", "water", "fire", "rock"];
                     foreach (TypeMongo type in defenderTypes)
                     {
                         if (fireStrongness.Contains(type.Name)) strongScore++;

--- a/PkmnRaceBattle.API/Helpers/MoveManager/Fights/FightPerformMove.cs
+++ b/PkmnRaceBattle.API/Helpers/MoveManager/Fights/FightPerformMove.cs
@@ -859,12 +859,12 @@ namespace PkmnRaceBattle.API.Helpers.MoveManager.Fights
             return multipliers[index];
         }
 
-        public static bool SpecialCaseFail(PokemonTeam attacker, PokemonTeamMove usedMove, PokemonTeam defenser)
+        public static bool SpecialCaseFail(PokemonTeam attacker, PokemonTeamMove attackerMove, PokemonTeam defenser, PokemonTeamMove defenserMove)
         {
-            switch (usedMove.NameFr)
+            switch (attackerMove.NameFr)
             {
                 case "Entrave":
-                    if (defenser.CantUseMoves.Count > 0) 
+                    if (defenser.CantUseMoves.Count > 0 || defenserMove.Type == "item" || defenserMove.Type == "swap")
                     {
                         return true;
                     }

--- a/PkmnRaceBattle.API/Helpers/MoveManager/ValidatorMove.cs
+++ b/PkmnRaceBattle.API/Helpers/MoveManager/ValidatorMove.cs
@@ -8,7 +8,7 @@ namespace PkmnRaceBattle.API.Helpers.MoveManager
     {
         public static bool IsEverythingOk(PlayerMongo player1, PokemonTeam pokemon1, PokemonTeamMove pokemon1Move, PlayerMongo player2, PokemonTeam pokemon2, PokemonTeamMove pokemon2Move, TurnContext turnContext)
         {
-            if(pokemon1.CurrHp <= 0 || pokemon2.CurrHp <= 0)
+            if(pokemon1Move.Type != "item" && pokemon1.CurrHp <= 0)
             {
                 turnContext.AddMessage("Un Pokémon K.O ne peut pas attaquer");
                 return false;
@@ -32,8 +32,19 @@ namespace PkmnRaceBattle.API.Helpers.MoveManager
                 return false;
             }
 
+            if(pokemon1Move.NameFr.Contains("ball") && pokemon2.Substitute != null)
+            {
+                turnContext.AddMessage("Cible invalide");
+                return false;
+            }
+
             if(pokemon1Move.Type == "item")
             {
+                if(pokemon1Move.NameFr == "Guérison" && (!FightUseItem.IsItemUseful(pokemon1, pokemon1Move.NameFr, turnContext) || pokemon1.CurrHp < pokemon1.BaseHp))
+                {
+                    return true;
+                }
+
                 if(pokemon1Move.DamageType == "ailment" && !FightUseItem.IsItemUseful(pokemon1, pokemon1Move.NameFr, turnContext)){
                     turnContext.AddMessage("Cela n'aura aucun effet");
                     return false;
@@ -53,7 +64,7 @@ namespace PkmnRaceBattle.API.Helpers.MoveManager
                         return false;
                     }
 
-                    if (pokemon1.CurrHp >= pokemon1.BaseHp ) 
+                    if (pokemon1.CurrHp >= pokemon1.BaseHp) 
                     {
                         turnContext.AddMessage(pokemon1.NameFr + " a déjà ses PV au max");
                         return false;


### PR DESCRIPTION
La roche ne résiste pas au feu
swap/obj sous entrave impossible
? Lorsqu'on swap enlever la confusion ?
Lorsqu'on se blesse dans la confusion empêcher de crit Revoir Hurlement/Cyclone/Téléportation
Capture d'un Pokémon sous clonage impossible
Empêcher la confusion quand déjà confus
Vampirisme et drain tjr bugué (jsp gros ça m'a soulé) Rappels qui fonctionnent pas
Si Pokémon en face capturé, ne pas appliquer les effets de fin de combat Guérison doit être possible si les pv sont au max mais un pb de statut Eviter d'apprendre une attaque déjà apprise
Le heal d'un Pokémon de la team ne s'affiche pas correctement visuellement